### PR TITLE
ADD 'line-height' css property

### DIFF
--- a/vendor/assets/stylesheets/_ribbon.sass
+++ b/vendor/assets/stylesheets/_ribbon.sass
@@ -15,6 +15,7 @@ $left: -60px
   height: $ribbon_height
   font-size: 16px
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif
+  line-height: 1rem
 
   // Position
   &.top-right


### PR DESCRIPTION
Force `line-height` property to `1rem` to avoid conflicts with own Rails project css.