### PR TITLE
RUN specs with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - gem install bundler -v 1.14.6
 
 script:
+  - bundle exec rake test
   - bin/rubocop
 
 notifications:


### PR DESCRIPTION
ADD missing command line that tells Travis to run specs.