### PR TITLE
ADD 'root_link' option that wraps ribbon

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ You can customize some options through the initializer. Here are the defaults op
 # git_branch: Current git branch (only displayed in development)
 config.infos_to_display = %i[rails_version ruby_version git_branch]
 
+config.root_link = false # Wrap ribbon with root_url link ?
+
 hide_for_small = true # Display ribbon in small devices ?
 position = 'top-left' # top-right, bottom-left, bottom-right
 sticky = true # stick to page corner ?

--- a/lib/app/views/partials/_lines.html.erb
+++ b/lib/app/views/partials/_lines.html.erb
@@ -1,0 +1,17 @@
+<span class="env"><%= Rails.env.capitalize %></span>
+
+<span class="version">
+  <% if config.infos_to_display.include?(:rails_version) %>
+    Rails: <strong><%= Rails.version %></strong>
+  <% end %>
+
+  <% if config.infos_to_display.include?(:ruby_version) %>
+    Ruby: <strong><%= RUBY_VERSION %></strong>
+  <% end %>
+</span>
+
+<% if config.infos_to_display.include?(:git_branch) && Rails.env.development? %>
+  <span class="git">
+    Branch: <strong><%= branch_name %></strong>
+  </span>
+<% end %>

--- a/lib/app/views/partials/_ribbon.html.erb
+++ b/lib/app/views/partials/_ribbon.html.erb
@@ -4,22 +4,12 @@
 
 <div id="ribbon" class="ribbon <%= config.position %> <%= config.hide_for_small ? 'hide-for-small' : '' %> <%= config.sticky ? 'sticky' : '' %> line-<%= line_count %>">
   <div class="ribbon-container <%= config.themes[Rails.env.to_sym] %>">
-    <span class="env"><%= Rails.env.capitalize %></span>
-
-    <span class="version">
-      <% if config.infos_to_display.include?(:rails_version) %>
-        Rails: <strong><%= Rails.version %></strong>
+    <% if config.root_link %>
+      <%= link_to root_url do %>
+        <%= render '/lines', config: config %>
       <% end %>
-
-      <% if config.infos_to_display.include?(:ruby_version) %>
-        Ruby: <strong><%= RUBY_VERSION %></strong>
-      <% end %>
-    </span>
-
-    <% if config.infos_to_display.include?(:git_branch) && Rails.env.development? %>
-      <span class="git">
-        Branch: <strong><%= branch_name %></strong>
-      </span>
+    <% else %>
+      <%= render '/lines', config: config %>
     <% end %>
   </div>
 </div>

--- a/lib/generators/ribbonit/templates/ribbonit.rb
+++ b/lib/generators/ribbonit/templates/ribbonit.rb
@@ -10,6 +10,11 @@ Ribbonit.configure do |config|
   config.infos_to_display = %i[rails_version ruby_version git_branch]
 
   ###
+  # Wrap ribbon with link that goes to root_url ?
+  #
+  config.root_link = false
+
+  ###
   # Display on small devices ?
   #
   config.hide_for_small = true

--- a/lib/ribbonit/configuration.rb
+++ b/lib/ribbonit/configuration.rb
@@ -16,6 +16,7 @@ class Ribbonit::Configuration
   config_accessor(:infos_to_display) do
     %i[rails_version ruby_version]
   end
+  config_accessor(:root_link) { false }
   config_accessor(:hide_for_small) { true }
   config_accessor(:position) { 'top-left' }
   config_accessor(:sticky) { true }

--- a/vendor/assets/stylesheets/_ribbon.sass
+++ b/vendor/assets/stylesheets/_ribbon.sass
@@ -81,6 +81,10 @@ $left: -60px
     text-decoration: none
     font-size: 1rem
     transform: rotate(-45deg)
+    a
+      display: block
+      color: #FFF
+      text-decoration: none
 
     &::before, &::after
       position: absolute
@@ -112,6 +116,8 @@ $left: -60px
     &.white
       background: #fff
       color: #333
+      a
+        color: #333
 
     // Displayed informations
     .env


### PR DESCRIPTION
In some design, the ribbon might appear just above the logo or the site title. It is then impossible to click it to go back to the homepage.

**Details**
- ADD `root_link` option
- UPDATE partial to `wrap` informations with a `link_to` if option is true 
- CREATE a `_lines` partial to render informations only
- UPDATE `README` instructions