### PR TITLE
REFACTOR way to define environments to apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ body
 ```
 
 ## Options
-You can customize some options through the initializer. Here are the defaults options:
+You can customize some options through the initializer. Here are the default ones:
 
 ```ruby
 # config/initializers/ribbonit.rb
@@ -73,13 +73,13 @@ Ribbonit.configure do |config|
   # orange, blue, green, red, purple, black, white
   config.themes = {
     development: 'black',
-    staging: 'blue'
+    staging: 'blue',
+    my_custom_environment: 'purple'
   }
-
-  # Sometimes, people use another name for this environment
-  config.staging_name = 'staging'
 end
 ```
+
+To add a custom environment, just add it inside the `themes` option and set the color you want (careful, if you define `config.themes` in your initializer it will erase default environments values so you will have to readd them).
 
 ## Screenshots
 ### Colors

--- a/lib/app/views/partials/_lines.html.erb
+++ b/lib/app/views/partials/_lines.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 </span>
 
-<% if config.infos_to_display.include?(:git_branch) && Rails.env.development? %>
+<% if config.infos_to_display.include?(:git_branch) %>
   <span class="ribbon__container__git">
     Branch: <strong><%= branch_name %></strong>
   </span>

--- a/lib/app/views/partials/_ribbon.html.erb
+++ b/lib/app/views/partials/_ribbon.html.erb
@@ -1,6 +1,6 @@
 <% config = Ribbonit.configuration %>
 
-<% if Rails.env.development? || Rails.env.send("#{config.staging_name}?") %>
+<% if config.themes.keys.include? Rails.env.to_sym %>
 
 <div id="ribbon" class="ribbon ribbon--<%= config.position %> <%= config.hide_for_small ? 'ribbon--hide-for-small' : '' %> <%= config.sticky ? 'ribbon--sticky' : '' %> ribbon--<%= line_count %>-lines">
   <div class="ribbon__container ribbon__container--<%= config.themes[Rails.env.to_sym] %>">

--- a/lib/generators/ribbonit/templates/ribbonit.rb
+++ b/lib/generators/ribbonit/templates/ribbonit.rb
@@ -42,9 +42,4 @@ Ribbonit.configure do |config|
     development: 'black',
     staging: 'blue'
   }
-
-  ###
-  # Environment name
-  #
-  config.staging_name = 'staging'
 end

--- a/lib/ribbonit/configuration.rb
+++ b/lib/ribbonit/configuration.rb
@@ -25,6 +25,5 @@ module Ribbonit
         staging: 'blue'
       }
     end
-    config_accessor(:staging_name) { 'staging' }
   end
 end

--- a/lib/ribbonit/view_helpers.rb
+++ b/lib/ribbonit/view_helpers.rb
@@ -12,7 +12,7 @@ module Ribbonit
       height = 1
       items = Ribbonit.configuration.infos_to_display
       height += 1 if items.include?(:ruby_version) || items.include?(:rails_version)
-      height += 1 if items.include?(:git_branch) && Rails.env.development?
+      height += 1 if items.include?(:git_branch)
       height
     end
   end


### PR DESCRIPTION
Some developers can define multiples environements other than
`development` or `staging`. With the actual code, it is not
possible to use the `ribbon`. Instead, a better way is to let
users to define inside the `themes` key which environements
and colors they want :)

Details:
- UPDATE conditions to display `ribbon`
- REMOVE unused configuration
- UPDATE documentation