### PR TITLE
Add `extra_content` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Ribbonit.configure do |config|
   # git_branch: Current git branch (only displayed in development)
   config.infos_to_display = %i[rails_version ruby_version git_branch]
 
+  # additional extra content to display at the bottom of ribbon
+  config.extra_content = nil # 'Foo bar'
+
   config.root_link = false # Wrap ribbon with root_url link ?
 
   config.hide_for_small = true # Display ribbon in small devices ?

--- a/app/assets/stylesheets/ribbon.css
+++ b/app/assets/stylesheets/ribbon.css
@@ -155,29 +155,46 @@
   transform: rotate(-45deg);
 }
 
+/* 3 lines */
+
 .ribbon--3-lines {
   width: calc(var(--ribbon-width) + 15px);
   height: calc(var(--ribbon-height) + 15px);
 }
 
-.ribbon--3-lines--top-left {
+.ribbon--3-lines.ribbon--top-left,
+.ribbon--4-lines.ribbon--top-left {
   top: var(--ribbon-offset);
   left: var(--ribbon-offset);
 }
 
-.ribbon--3-lines--top-right {
+.ribbon--3-lines.ribbon--top-right,
+.ribbon--4-lines.ribbon--top-right {
   top: var(--ribbon-offset);
   right: var(--ribbon-offset);
 }
 
-.ribbon--3-lines--bottom-left {
+.ribbon--3-lines.ribbon--bottom-left,
+.ribbon--4-lines.ribbon--bottom-left {
   bottom: var(--ribbon-offset);
   left: var(--ribbon-offset);
 }
 
-.ribbon--3-lines--bottom-right {
+.ribbon--3-lines.ribbon--bottom-right,
+.ribbon--4-lines.ribbon--bottom-right {
   right: var(--ribbon-offset);
   bottom: var(--ribbon-offset);
+}
+
+/* 4 lines */
+
+.ribbon--4-lines {
+  width: calc(var(--ribbon-width) + 30px);
+  height: calc(var(--ribbon-height) + 30px);
+}
+
+.ribbon--4-lines .ribbon__container {
+  width: 280px;
 }
 
 @media only screen and (max-width: 40em) {

--- a/app/views/application/_lines.html.erb
+++ b/app/views/application/_lines.html.erb
@@ -15,3 +15,9 @@
     Branch: <strong><%= branch_name %></strong>
   </span>
 <% end %>
+
+<% if config.extra_content.present? %>
+  <span class="ribbon__container__extra">
+    <%= config.extra_content %>
+  </span>
+<% end %>

--- a/lib/generators/ribbonit/templates/ribbonit.rb
+++ b/lib/generators/ribbonit/templates/ribbonit.rb
@@ -10,6 +10,11 @@ Ribbonit.configure do |config|
   config.infos_to_display = %i[rails_version ruby_version git_branch]
 
   ###
+  # Extra content to add at the end
+  #
+  config.extra_content = nil
+
+  ###
   # Wrap ribbon with link that goes to root_url ?
   #
   config.root_link = false

--- a/lib/ribbonit/configuration.rb
+++ b/lib/ribbonit/configuration.rb
@@ -15,6 +15,7 @@ module Ribbonit
     config_accessor(:infos_to_display) do
       %i[rails_version ruby_version]
     end
+    config_accessor(:extra_content) { nil }
     config_accessor(:root_link) { false }
     config_accessor(:hide_for_small) { true }
     config_accessor(:position) { 'top-left' }

--- a/lib/ribbonit/view_helpers.rb
+++ b/lib/ribbonit/view_helpers.rb
@@ -10,10 +10,17 @@ module Ribbonit
 
     def line_count
       height = 1
-      items = Ribbonit.configuration.infos_to_display
+      items = configuration.infos_to_display
       height += 1 if items.include?(:ruby_version) || items.include?(:rails_version)
       height += 1 if items.include?(:git_branch)
+      height += 1 if configuration.extra_content.present?
       height
+    end
+
+    private
+
+    def configuration
+      Ribbonit.configuration
     end
   end
 end


### PR DESCRIPTION
Fix #27

Add a new `extra_content` line to allow display of custom text value.

<img width="201" alt="ribbon-extra-content" src="https://github.com/anthony-robin/ribbonit/assets/5428510/3f99d6d1-1f8e-4641-9c3a-a49d9c3bb714">
