### PR TITLE
Remove `codacy-coverage` dependency

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,5 @@
-require 'codacy-coverage'
-
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    Codacy::Formatter
+    SimpleCov::Formatter::HTMLFormatter
 ])
 
 SimpleCov.start do

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 It is completely inspired from the Github 'fork me' ribbon.
 
 [![Gem Version](https://badge.fury.io/rb/ribbonit.svg)](https://rubygems.org/gems/ribbonit)
-[![Travis CI](https://travis-ci.org/anthony-robin/Ribbonit.svg?branch=master)](https://travis-ci.org/anthony-robin/Ribbonit)
-[![Codacy Badge Grade](https://api.codacy.com/project/badge/Grade/521429a8cf91432aba574c69f1385aa2)](https://www.codacy.com/app/anthony-robin/Ribbonit)
-[![Codacy Badge Coverage](https://api.codacy.com/project/badge/Coverage/521429a8cf91432aba574c69f1385aa2)](https://www.codacy.com/app/anthony-robin/Ribbonit)
-[![Dependency Status](https://gemnasium.com/badges/github.com/anthony-robin/Ribbonit.svg)](https://gemnasium.com/github.com/anthony-robin/Ribbonit)
 
 ## Installation
 

--- a/ribbonit.gemspec
+++ b/ribbonit.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'codacy-coverage', '~> 1.1'
 end


### PR DESCRIPTION
Project does not use anymore Codacy, time to remove `codacy-coverage` from project.

Unused badges are also removed from `README` such as `Codacy`, `Travis` or `Gemnasium`.